### PR TITLE
Extra slot for null terminator

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -134,7 +134,9 @@ buffer_resize(buffer_t *self, size_t n) {
   n = nearest_multiple_of(1024, n);
   self->len = n;
   self->alloc = self->data = realloc(self->alloc, n + 1);
-  return self->alloc ? 0 : -1;
+  if (!self->alloc) return -1;
+  self->alloc[n] = '\0';
+  return 0;
 }
 
 /*


### PR DESCRIPTION
Since the `data` attribute is manipulated as a character string (and used as input for `strlen`, `strcmp`, ...) every library function that **directly** (re)allocates the internal buffer should take care to include an extra slot filled with the null terminator.

The following functions are concerned and have been modified accordingly:
- `buffer_new_with_size`
- `buffer_compact`
- `buffer_resize`

By doing this there is no need to allocate such an extra space for `buffer_slice` anymore since it does not _directly_ handle the internal buffer.

This patch solves all Valgrind errors (invalid read, etc) due to the fact that `data` was not guaranteed to always be null terminated.
