### PR TITLE
`size_t` and `ssize_t` requires include `string.h`

### DIFF
--- a/buffer.h
+++ b/buffer.h
@@ -1,4 +1,3 @@
-
 //
 // buffer.h
 //
@@ -7,6 +6,7 @@
 
 #ifndef BUFFER
 #define BUFFER
+#include <string.h>
 
 /*
  * Default buffer size.


### PR DESCRIPTION
Below errors are expected to be eliminated :p

``` sh
deps/buffer/buffer.h:64:1: error: unknown type name 'ssize_t'
ssize_t
^
```

/cc @clibs
