### PR TITLE
Functions to append/prepend with printf formatting

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -6,6 +6,7 @@
 
 #include <string.h>
 #include <stdio.h>
+#include <stdarg.h>
 #include <stdlib.h>
 #include <ctype.h>
 #include <sys/types.h>
@@ -138,6 +139,50 @@ buffer_resize(buffer_t *self, size_t n) {
   self->alloc[n] = '\0';
   return 0;
 }
+
+/*
+ * Append or prepend a formatted string to the buffer.
+ */
+static int buffer_format_helper(buffer_t *self, const char* format, va_list ap,
+    int front) {
+  char *formatted;
+  int bytes_appended, bytes_formatted;
+  bytes_formatted = vasprintf(&formatted, format, ap);
+  if (bytes_formatted < 0) {
+    return -1;
+  }
+
+  if (front) {
+    bytes_appended = buffer_append(self, formatted);
+  } else {
+    bytes_appended = buffer_prepend(self, formatted);
+  }
+  free(formatted);
+  return bytes_appended;
+}
+
+/*
+ * Append a printf-style formatted string to the buffer.
+ */
+int buffer_appendf(buffer_t *self, const char *format, ...) {
+  va_list ap;
+  va_start(ap, format);
+  const int ret = buffer_format_helper(self, format, ap, 1);
+  va_end(ap);
+  return ret;
+}
+
+/*
+ * Prepend a printf-style formatted string to the buffer.
+ */
+int buffer_prependf(buffer_t *self, const char *format, ...) {
+  va_list ap;
+  va_start(ap, format);
+  const int ret = buffer_format_helper(self, format, ap, 0);
+  va_end(ap);
+  return ret;
+}
+
 
 /*
  * Append `str` to `self` and return 0 on success, -1 on failure.

--- a/buffer.h
+++ b/buffer.h
@@ -58,7 +58,13 @@ int
 buffer_prepend(buffer_t *self, char *str);
 
 int
+buffer_prependf(buffer_t *self, const char *format, ...);
+
+int
 buffer_append(buffer_t *self, const char *str);
+
+int
+buffer_appendf(buffer_t *self, const char *format, ...);
 
 int
 buffer_append_n(buffer_t *self, const char *str, size_t len);

--- a/test.c
+++ b/test.c
@@ -148,6 +148,16 @@ test_buffer_equals() {
   buffer_free(b);
 }
 
+void test_buffer_formatting() {
+  buffer_t *buf = buffer_new();
+  int result = buffer_appendf(buf, "%d %s", 3, "cow");
+  assert(0 == result);
+  result = buffer_prependf(buf, "0x%08X - ", 0xdeadbeef);
+  assert(0 == result);
+  equal("0xDEADBEEF - 3 cow", buffer_string(buf));
+  buffer_free(buf);
+}
+
 void
 test_buffer_indexof() {
   buffer_t *buf = buffer_new_with_copy("Tobi is a ferret");
@@ -231,6 +241,7 @@ main(){
   test_buffer_slice__end();
   test_buffer_slice__end_overflow();
   test_buffer_equals();
+  test_buffer_formatting();
   test_buffer_indexof();
   test_buffer_fill();
   test_buffer_clear();


### PR DESCRIPTION
Add buffer_appendf and bugger_prependf to allow the
user to append or prepend a string formatted with
printf-style syntax.

Fixes #3
