### PR TITLE
Functions to append/prepend with printf formatting

### DIFF
--- a/buffer.h
+++ b/buffer.h
@@ -58,9 +58,6 @@ int
 buffer_prepend(buffer_t *self, char *str);
 
 int
-buffer_prependf(buffer_t *self, const char *format, ...);
-
-int
 buffer_append(buffer_t *self, const char *str);
 
 int

--- a/buffer.h
+++ b/buffer.h
@@ -58,7 +58,13 @@ int
 buffer_prepend(buffer_t *self, char *str);
 
 int
+buffer_prependf(buffer_t *self, const char *format, ...);
+
+int
 buffer_append(buffer_t *self, const char *str);
+
+int
+buffer_appendf(buffer_t *self, const char *format, ...);
 
 int
 buffer_append_n(buffer_t *self, const char *str, size_t len);

--- a/test.c
+++ b/test.c
@@ -148,6 +148,16 @@ test_buffer_equals() {
   buffer_free(b);
 }
 
+void test_buffer_formatting() {
+  buffer_t *buf = buffer_new();
+  int result = buffer_appendf(buf, "%d %s", 3, "cow");
+  assert(0 == result);
+  result = buffer_prependf(buf, "0x%08X - ", 0xdeadbeef);
+  assert(0 == result);
+  equal("0xDEADBEEF - 3 cow", buffer_string(buf));
+  buffer_free(buf);
+}
+
 void
 test_buffer_indexof() {
   buffer_t *buf = buffer_new_with_copy("Tobi is a ferret");
@@ -231,6 +241,7 @@ main(){
   test_buffer_slice__end();
   test_buffer_slice__end_overflow();
   test_buffer_equals();
+  test_buffer_formatting();
   test_buffer_indexof();
   test_buffer_fill();
   test_buffer_clear();

--- a/test.c
+++ b/test.c
@@ -149,20 +149,13 @@ test_buffer_equals() {
 }
 
 void test_buffer_formatting() {
-
-  buffer_t *buf = buffer_new_with_copy("123");
-  buffer_prependf(buf, "abcde");
-  equal("abcde123", buffer_string(buf));
-  buffer_free(buf);
-
-  //buffer_t *
-    buf = buffer_new();
+  buffer_t *buf = buffer_new();
   int result = buffer_appendf(buf, "%d %s", 3, "cow");
   assert(0 == result);
   equal("3 cow", buffer_string(buf));
-  result = buffer_prependf(buf, "0x%08X - ", 0xdeadbeef);
+  result = buffer_appendf(buf, " - 0x%08X", 0xdeadbeef);
   assert(0 == result);
-  equal("0xDEADBEEF - 3 cow", buffer_string(buf));
+  equal("3 cow - 0xDEADBEEF", buffer_string(buf));
   buffer_free(buf);
 }
 

--- a/test.c
+++ b/test.c
@@ -149,9 +149,17 @@ test_buffer_equals() {
 }
 
 void test_buffer_formatting() {
-  buffer_t *buf = buffer_new();
+
+  buffer_t *buf = buffer_new_with_copy("123");
+  buffer_prependf(buf, "abcde");
+  equal("abcde123", buffer_string(buf));
+  buffer_free(buf);
+
+  //buffer_t *
+    buf = buffer_new();
   int result = buffer_appendf(buf, "%d %s", 3, "cow");
   assert(0 == result);
+  equal("3 cow", buffer_string(buf));
   result = buffer_prependf(buf, "0x%08X - ", 0xdeadbeef);
   assert(0 == result);
   equal("0xDEADBEEF - 3 cow", buffer_string(buf));


### PR DESCRIPTION
Add buffer_appendf and bugger_prependf to allow the
user to append or prepend a string formatted with
printf-style syntax.

Fixes #3